### PR TITLE
sensors: rename sensors.msm8916.so stock HAL so that we can wrap it

### DIFF
--- a/idol3/idol3-vendor.mk
+++ b/idol3/idol3-vendor.mk
@@ -518,8 +518,8 @@ PRODUCT_COPY_FILES += \
     vendor/alcatel/idol3/proprietary/lib/libnetd_client.so:system/lib/libnetd_client.so \
     vendor/alcatel/idol3/proprietary/lib/libril.so:system/lib/libril.so \
     vendor/alcatel/idol3/proprietary/lib/sensors.native.so:system/lib/sensors.native.so \
-    vendor/alcatel/idol3/proprietary/lib/hw/sensors.msm8916.so:system/lib/hw/sensors.msm8916.so \
-    vendor/alcatel/idol3/proprietary/lib64/hw/sensors.msm8916.so:system/lib64/hw/sensors.msm8916.so \
+    vendor/alcatel/idol3/proprietary/lib/hw/sensors.msm8916.so:system/lib/hw/sensors.stockmsm8916.so \
+    vendor/alcatel/idol3/proprietary/lib64/hw/sensors.msm8916.so:system/lib64/hw/sensors.stockmsm8916.so \
     vendor/alcatel/idol3/proprietary/vendor/lib/mmi_sensor.so:system/vendor/lib/mmi_sensor.so \
     vendor/alcatel/idol3/proprietary/vendor/lib64/mmi_sensor.so:system/vendor/lib64/mmi_sensor.so \
     vendor/alcatel/idol3/proprietary/lib64/hw/audio.primary.msm8916.so:system/lib64/hw/audio.primary.msm8916.so \


### PR DESCRIPTION
and fix proximity sensor being reported as non-wakeup sensor using
HAL chaining technique :
http://www.hy-research.com/download/ABS2015-ChainingHAL-2.pdf
https://www.youtube.com/watch?v=V3ZSXq8x1ME

Change-Id: I8e42544890ba05cf1857c4a059ce906bb0f9f81d